### PR TITLE
Updated to use Ransack 4.0 and Chronic 0.10.2

### DIFF
--- a/lib/ransack_chronic/version.rb
+++ b/lib/ransack_chronic/version.rb
@@ -1,3 +1,3 @@
 module RansackChronic
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/lib/ransack_overrides/nodes/value.rb
+++ b/lib/ransack_overrides/nodes/value.rb
@@ -1,5 +1,3 @@
-require 'ransack/nodes'
-
 # Add Chronic parsing to date and time casting
 module Ransack
   module Nodes

--- a/ransack_chronic.gemspec
+++ b/ransack_chronic.gemspec
@@ -1,7 +1,5 @@
-# -*- encoding: utf-8 -*-
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'ransack_chronic/version'
+# encoding: utf-8
+require_relative 'lib/ransack_chronic/version'
 
 Gem::Specification.new do |gem|
   gem.name          = "ransack_chronic"
@@ -10,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["nathan.f77@gmail.com"]
   gem.description   = %q{Parse time/date natural language query strings with Chronic}
   gem.summary       = %q{Parse time/date query strings with Chronic}
-  gem.homepage      = ""
+  gem.homepage      = "https://github.com/ndbroadbent/ransack_chronic"
   gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($/)
@@ -18,5 +16,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'chronic', '>= 0.6.7'
+  gem.add_dependency 'chronic', '~> 0.10.2', '>= 0.10.2'
+  gem.add_dependency 'ransack', '~> 4.0'
 end


### PR DESCRIPTION
I was getting security warnings with my use of Ransack 2.4.1. It was telling me to upgrade to Ransack 4.0.0. I found that Ransack 4.0.0 would not work with ransack_chronic so I updated it. I figured I might as well update Chronic while at it.